### PR TITLE
Better Import practice

### DIFF
--- a/R/coinmarketcapr.R
+++ b/R/coinmarketcapr.R
@@ -1,7 +1,3 @@
-#'@import ggplot2
-#'@import RCurl
-#'@import jsonlite
-
 currencies_list <- c("AUD", "BRL", "CAD", "CHF", "CLP", "CNY", "CZK", "DKK", "EUR", "GBP", "HKD", "HUF", "IDR", "ILS", "INR", "JPY", "KRW", "MXN", "MYR", "NOK", "NZD", "PHP", "PKR", "PLN", "RUB", "SEK", "SGD", "THB", "TRY", "TWD", "ZAR", "USD")
 
 


### PR DESCRIPTION
If you already included dependencies like `ggplot2`, `RCurl` and `jsonlite` in the `DESCRIPTION` file, you don't need to include `#'@import package` when you access their functions through the use of `::`.
In fact the whole point of using `::` is to avoid doing `#'@import package`.
Ref: http://r-pkgs.had.co.nz/namespace.html#imports