### PR TITLE
respect further parameters, especially 'limit', if latest is TRUE

### DIFF
--- a/R/currencies.R
+++ b/R/currencies.R
@@ -155,6 +155,10 @@ get_crypto_listings <- function(currency = "USD", latest = TRUE, ...) {
     ## Build Request (new API) ##########
     if (latest) {
         what <- paste0("cryptocurrency/listings/latest?convert=", currency)
+        whatelse <- list(...)
+        whatelse <- transform_args(whatelse)
+        if (!is.null(whatelse))
+            what <- paste0(what, "&", whatelse)
     } else {
         what <- paste0("cryptocurrency/listings/historical?convert=", currency)
         whatelse <- list(...)


### PR DESCRIPTION
To save API credits, it would be nice to be able to call 'get_crypto_listings' with parameter 'limit=200' even if latest is TRUE, which is easily achieved with the tiny modifications in this commit/request.